### PR TITLE
(QENG-4629) Use TCP connection to graphite.

### DIFF
--- a/jira-dependency-graph.py
+++ b/jira-dependency-graph.py
@@ -181,7 +181,7 @@ def create_graph_image(graph_data, image_file):
 
 def submit_metrics_to_graphite(host, port, values=[]):
     sock = socket.socket(socket.AF_INET,
-                         socket.SOCK_DGRAM)
+                         socket.SOCK_STREAM)
     sock.connect((host, port))
     timestamp = int(time.time())
     for path, value in values:


### PR DESCRIPTION
Running this against our test graphite instance worked, but it failed
when run against our production graphite instance because the production
instance is behind a load balancer.

I suspect the CLI should probably have a flag to toggle between TCP and
UDP but TCP seems to work well enough for both test and prod use cases
in our infrastructure so I'll leave the CLI flag for someone who needs
it to implement.